### PR TITLE
Render annotated container file images

### DIFF
--- a/packages/react/src/contexts/markdown/MarkdownContext/lib/components/Img/index.test.tsx
+++ b/packages/react/src/contexts/markdown/MarkdownContext/lib/components/Img/index.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+import { Img } from '.'
+
+vi.mock('@/hooks/core/useSuperinterfaceContext', () => ({
+  useSuperinterfaceContext: () => ({
+    baseUrl: '/api',
+    variables: {
+      assistantId: 'asst_1',
+      publicApiKey: 'public_1',
+    },
+  }),
+}))
+
+vi.mock('@/components/images/Image', () => ({
+  Image: (props: JSX.IntrinsicElements['img']) => (
+    <img
+      data-testid="image"
+      {...props}
+    />
+  ),
+}))
+
+describe('Markdown Img', () => {
+  test('rewrites an annotated container image to the authenticated file proxy', () => {
+    const annotation = JSON.stringify({
+      type: 'file_path',
+      file_path: {
+        file_id: 'cfile_chart',
+        container_id: 'cntr_chart',
+      },
+    })
+
+    render(
+      <Img
+        alt="Quarterly chart"
+        src="sandbox:/mnt/data/chart.png"
+        data-file-annotation={annotation}
+      />,
+    )
+
+    const image = screen.getByTestId('image')
+    expect(image.getAttribute('src')).toBe(
+      '/api/files/cfile_chart/contents?assistantId=asst_1&publicApiKey=public_1&containerId=cntr_chart',
+    )
+    expect(image.hasAttribute('data-file-annotation')).toBe(false)
+  })
+
+  test('rewrites an annotated non-container image without a container id', () => {
+    const annotation = JSON.stringify({
+      type: 'file_path',
+      file_path: { file_id: 'file_chart' },
+    })
+
+    render(
+      <Img
+        alt="Chart"
+        src="sandbox:/mnt/data/chart.png"
+        data-file-annotation={annotation}
+      />,
+    )
+
+    expect(screen.getByTestId('image').getAttribute('src')).toBe(
+      '/api/files/file_chart/contents?assistantId=asst_1&publicApiKey=public_1',
+    )
+  })
+
+  test('keeps the original source when annotation JSON is malformed', () => {
+    render(
+      <Img
+        alt="Fallback"
+        src="https://example.com/chart.png"
+        data-file-annotation="not-json"
+      />,
+    )
+
+    expect(screen.getByTestId('image').getAttribute('src')).toBe(
+      'https://example.com/chart.png',
+    )
+  })
+
+  test('keeps regular unannotated images unchanged', () => {
+    render(
+      <Img
+        alt="Public"
+        src="https://example.com/public.png"
+      />,
+    )
+
+    expect(screen.getByTestId('image').getAttribute('src')).toBe(
+      'https://example.com/public.png',
+    )
+  })
+})

--- a/packages/react/src/contexts/markdown/MarkdownContext/lib/components/Img/index.tsx
+++ b/packages/react/src/contexts/markdown/MarkdownContext/lib/components/Img/index.tsx
@@ -3,30 +3,44 @@ import { isVideoSrc } from './lib/isVideoSrc'
 import { isAudioSrc } from './lib/isAudioSrc'
 import { Video } from './Video'
 import { Audio } from './Audio'
+import { useSuperinterfaceContext } from '@/hooks/core/useSuperinterfaceContext'
 
-export const Img = (props: JSX.IntrinsicElements['img']) => {
-  if (!props.src) {
-    return (
-      <Image
-        {...props}
-      />
-    )
-  } else if (isVideoSrc({ src: props.src })) {
-    return (
-      <Video
-        src={props.src!}
-      />
-    )
-  } else if (isAudioSrc({ src: props.src })) {
-    return (
-      <Audio
-        src={props.src!}
-      />
-    )
+type ImgProps = JSX.IntrinsicElements['img'] & {
+  'data-file-annotation'?: string
+}
+
+type FilePathAnnotation = {
+  file_path: { file_id: string; container_id?: string }
+}
+
+export const Img = (props: ImgProps) => {
+  const superinterfaceContext = useSuperinterfaceContext()
+  const serializedAnnotation = props['data-file-annotation']
+
+  let src = props.src
+  if (serializedAnnotation) {
+    try {
+      const annotation = JSON.parse(serializedAnnotation) as FilePathAnnotation
+      const searchParams = new URLSearchParams(superinterfaceContext.variables)
+      if (annotation.file_path.container_id) {
+        searchParams.set('containerId', annotation.file_path.container_id)
+      }
+      src = `${superinterfaceContext.baseUrl}/files/${annotation.file_path.file_id}/contents?${searchParams}`
+    } catch {}
+  }
+
+  if (!src) {
+    return <Image {...props} />
+  } else if (isVideoSrc({ src: props.src ?? src })) {
+    return <Video src={src} />
+  } else if (isAudioSrc({ src: props.src ?? src })) {
+    return <Audio src={src} />
   } else {
     return (
       <Image
         {...props}
+        data-file-annotation={undefined}
+        src={src}
       />
     )
   }

--- a/packages/react/src/lib/remark/markdownPipeline.test.ts
+++ b/packages/react/src/lib/remark/markdownPipeline.test.ts
@@ -354,6 +354,27 @@ describe('full markdown pipeline', () => {
       const result = await compileFullPipeline(text, [])
       expect(result).not.toContain('_components.annotation')
     })
+
+    test('annotated sandbox image compiles with file metadata for the img component', async () => {
+      const url = 'sandbox:/mnt/data/chart.png'
+      const text = `![Chart](${url})`
+      const annotation = {
+        type: 'file_path',
+        text: '',
+        start_index: text.indexOf(url),
+        end_index: text.indexOf(url) + url.length,
+        file_path: {
+          file_id: 'cfile_chart',
+          container_id: 'cntr_chart',
+        },
+      }
+      const result = await compileFullPipeline(text, [annotation])
+
+      expect(result).toContain('_components.img')
+      expect(result).toContain('data-file-annotation')
+      expect(result).toContain('cfile_chart')
+      expect(result).toContain('cntr_chart')
+    })
   })
 
   describe('realistic AI response patterns', () => {

--- a/packages/react/src/lib/remark/remarkAnnotation.responsesApi.test.ts
+++ b/packages/react/src/lib/remark/remarkAnnotation.responsesApi.test.ts
@@ -38,3 +38,43 @@ test('an annotated Markdown link keeps separate file and container ids', () => {
     JSON.parse(node.data.hProperties['data-annotation']).file_path,
   ).toEqual({ file_id: 'cfile_xyz', container_id: 'cntr_abc' })
 })
+
+test('an annotated Markdown image exposes the same ids to the img renderer', () => {
+  const url = 'sandbox:/mnt/data/chart.png'
+  const text = `![Chart](${url})`
+  const tree = parse(text, annotationFor(text, url))
+  const image = tree.children[0].children[0]
+
+  expect(image.type).toBe('image')
+  expect(
+    JSON.parse(image.data.hProperties['data-file-annotation']).file_path,
+  ).toEqual({ file_id: 'cfile_xyz', container_id: 'cntr_abc' })
+})
+
+test('does not annotate a Markdown image when the file path is outside it', () => {
+  const imageUrl = 'https://example.com/chart.png'
+  const fileUrl = 'sandbox:/mnt/data/report.pdf'
+  const text = `![Chart](${imageUrl}) [Download](${fileUrl})`
+  const tree = parse(text, annotationFor(text, fileUrl))
+  const image = tree.children[0].children[0]
+
+  expect(image.type).toBe('image')
+  expect(image.data?.hProperties?.['data-file-annotation']).toBeUndefined()
+})
+
+test('does not bridge non-file annotations to Markdown images', () => {
+  const url = 'sandbox:/mnt/data/chart.png'
+  const text = `![Chart](${url})`
+  const annotation = {
+    type: 'file_citation',
+    text: '【1:1†source】',
+    start_index: text.indexOf(url),
+    end_index: text.indexOf(url) + url.length,
+    file_citation: { file_id: 'file_source' },
+  } as any
+  const tree = parse(text, annotation)
+  const image = tree.children[0].children[0]
+
+  expect(image.type).toBe('image')
+  expect(image.data?.hProperties?.['data-file-annotation']).toBeUndefined()
+})

--- a/packages/react/src/lib/remark/remarkAnnotation.ts
+++ b/packages/react/src/lib/remark/remarkAnnotation.ts
@@ -1,7 +1,7 @@
 import type OpenAI from 'openai'
 import { isNumber } from 'radash'
 import type { Node, Literal, Position } from 'unist'
-import type { Text, Link } from 'mdast'
+import type { Text, Link, Image } from 'mdast'
 // @ts-ignore-next-line
 import flatMap from 'unist-util-flatmap'
 
@@ -57,7 +57,11 @@ export const remarkAnnotation = ({
   return () => {
     return (tree: any) => {
       flatMap(tree, (node: Node) => {
-        if (node.type === 'text' || node.type === 'link') {
+        if (
+          node.type === 'text' ||
+          node.type === 'link' ||
+          node.type === 'image'
+        ) {
           const result = processNodeWithAnnotations({ node, content })
 
           // If broken annotations detected, strip leftover 【...】 markers from text nodes
@@ -202,6 +206,28 @@ const processNodeWithAnnotations = ({
     } else {
       return [linkNode]
     }
+  } else if (node.type === 'image') {
+    const imageNode = node as Image
+    const nodeStart = imageNode.position?.start.offset
+    const nodeEnd = imageNode.position?.end.offset
+    if (!isNumber(nodeStart) || !isNumber(nodeEnd)) return [imageNode]
+
+    const annotation = annotations.find(
+      (candidate) =>
+        candidate.type === 'file_path' &&
+        candidate.start_index >= nodeStart &&
+        candidate.end_index <= nodeEnd,
+    )
+    if (!annotation) return [imageNode]
+
+    imageNode.data = {
+      ...(imageNode.data ?? {}),
+      hProperties: {
+        ...((imageNode.data as any)?.hProperties ?? {}),
+        'data-file-annotation': JSON.stringify(annotation),
+      },
+    }
+    return [imageNode]
   } else {
     return [node]
   }


### PR DESCRIPTION
## What changed

- attach matching Responses API `file_path` annotations to Markdown image nodes
- resolve annotated image sources through the existing authenticated file contents route
- preserve both `file_id` and optional `container_id`
- leave ordinary, unannotated images unchanged

## Why

Responses API code interpreter can return generated images as annotated Markdown such as `![Chart](sandbox:/mnt/data/chart.png)`. Download links already consumed those annotations, but image nodes retained the unusable `sandbox:` URL, so the browser rendered an empty/broken preview.

## Impact

Generated container images now render inline through the same live container-file endpoint used by downloads. This changes only `@superinterface/react`; there are no database, Supercompat, or Cloud API changes.

## Validation

- focused annotation, full MDX pipeline, and image renderer tests: 49 passed
- full React suite: 99 passed; the existing `useMessageAudio > custom play receives incremental updates` test still fails in isolation on `main`
- React package build: passed
- TypeScript lint reaches existing unrelated errors in `useMessageAudio/lib/useDefaultPlay.ts` and `createMessageResponse/handleStream.ts`
